### PR TITLE
Update example app Go version to 1.12 to support latest CF Go buildpack

### DIFF
--- a/assets/logsearch-example-app/Godeps/Godeps.json
+++ b/assets/logsearch-example-app/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/cloudfoundry-community/logsearch-smoke-tests/assets/logsearch-example-app",
-	"GoVersion": "go1.11",
+	"GoVersion": "go1.12",
 	"GodepVersion": "v80",
 	"Deps": [
 		{


### PR DESCRIPTION
Go 1.11 is [no longer supported](https://github.com/cloudfoundry/go-buildpack/releases) by the Cloud Foundry Go buildpack meaning the example app no longer worked for users running the latest buildpack.

This PR updates the example app to use Go 1.12 and I have verified that it works with the latest CF Go buildpack.

Note that Go 1.13 was only released ten days ago I opted for 1.12 to avoid breaking the app for anyone *not* running the latest CF buildpack.