### PR TITLE
Update test app go version to 1.15

### DIFF
--- a/assets/logsearch-example-app/Godeps/Godeps.json
+++ b/assets/logsearch-example-app/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/cloudfoundry-community/logsearch-smoke-tests/assets/logsearch-example-app",
-	"GoVersion": "go1.13",
+	"GoVersion": "go1.15",
 	"GodepVersion": "v80",
 	"Deps": [
 		{


### PR DESCRIPTION
Go 1.13 is now deprecated by the [Go buildpack 1.9.20](https://github.com/cloudfoundry/go-buildpack/releases/tag/v1.9.20). I have tested this change and confirmed that the smoke tests pass with the updated test app.