### PR TITLE
Update test app to work with latest buildpack

### DIFF
--- a/assets/logsearch-example-app/Godeps/Godeps.json
+++ b/assets/logsearch-example-app/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/cloudfoundry-community/logsearch-smoke-tests/assets/logsearch-example-app",
-	"GoVersion": "go1.15",
+	"GoVersion": "go1.16",
 	"GodepVersion": "v80",
 	"Deps": [
 		{


### PR DESCRIPTION
Does exactly the same as https://github.com/cloudfoundry-community/logsearch-smoke-tests/pull/5 and https://github.com/cloudfoundry-community/logsearch-smoke-tests/pull/7, but to Go 1.16 since Go 1.15 is [now deprecated](https://github.com/cloudfoundry/go-buildpack/releases/tag/v1.9.35).

I've confirmed that the change fixes smoke tests using the new buildpack.